### PR TITLE
zsh isn't always in /usr/bin

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
-#!/usr/bin/zsh
+#!/usr/bin/env zsh
 
 if curl -s localhost:9200 >/dev/null; then
   for cmd in `es help 2>&1 | egrep '^  [a-z]'`; do


### PR DESCRIPTION
But `env` is there, and should be used to check paths for interpreters.
