### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ test:
 
 package: clean test
 	lein bin
+
+install: package
 	cp target/es ~/bin
 
-deploy: package
+deploy: install
 	s3cmd -c ${S3CREDS} put -P target/es ${S3HOME}/es-${VERSION}
 	s3cmd -c ${S3CREDS} cp ${S3HOME}/es-${VERSION} ${S3HOME}/es


### PR DESCRIPTION
A 'package' target should never automatically install the project. This adds an install target and changes deploy to use it.
