### PR TITLE
Fetch relative to provided URL and path

### DIFF
--- a/src/es/http.clj
+++ b/src/es/http.clj
@@ -67,5 +67,6 @@
     ([]
        (f "/"))
     ([path]
-       (let [url (-> (URL. base) (URL. path) str)]
-         (get url)))))
+       (let [path (clojure.string/replace path #"^\/+" "")]
+       (let [url (str (URL. (URL. base) path))]
+         (get url))))))


### PR DESCRIPTION
I access my Elasticsearch instance through a reverse-proxy. It pretty much looks like this: "http://some.host.com/es/(.*)" -> "http://localhost:9200/$1". The base of my elasticsearch instance is found at "/es/" rather than "/". 

If I make the following request:
`es2unix -u http://some.host.com/es/ health`
The current master will query "http://some.host.com/_cluster/health".

This patch adjusts the behavior so that the provided URL is treated as the full base path, and all URLs are fetched relative to that path. 
So, now, the command:
`es2unix -u http://some.host.com/es/ health`
Will query send a request to "http://some.host.com/es/_cluster/health", which makes me a very happy person.

Thanks!
